### PR TITLE
Fix for keepEmptyBody. Option was never used.

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -441,7 +441,7 @@ export class Resource {
     }
 
 
-    if (typeof body === 'object' && Object.keys(body).length === 0) {
+    if (typeof body === 'object' && Object.keys(body).length === 0 && !options.actionOptions.keepEmptyBody) {
       return;
     }
 


### PR DESCRIPTION
Not possible to have an empty body. keepEmptyBody option was never used